### PR TITLE
Fix handling of universes.

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,8 +1,8 @@
 -R theories/ MTranslate
 
-COQTOP = /Users/kquiri13/Code/Coq/HoTT8.5/HoTT/hoqtop
-COQC = /Users/kquiri13/Code/Coq/HoTT8.5/HoTT/hoqc
-COQDEP = /Users/kquiri13/Code/Coq/HoTT8.5/HoTT/hoqdep
+COQTOP = ${HOTTBIN)/hoqtop
+COQC = ${HOTTBIN}/hoqc
+COQDEP = ${HOTTBIN}/hoqdep
 
 -I src/
 

--- a/src/g_modal.ml4
+++ b/src/g_modal.ml4
@@ -1,7 +1,7 @@
 DECLARE PLUGIN "mTranslate"
 
 TACTIC EXTEND modal
-| [ "modal" constr(refl) constr(univ) constr(univ_to_univ) constr(forall) constr(unit) constr(c) "as" ident(id)] -> [
+| [ "modal" reference(refl) reference(univ) reference(univ_to_univ) reference(forall) reference(unit) constr(c) "as" ident(id)] -> [
   let modality = {
       MTranslate.mod_O = refl;
       MTranslate.mod_univ = univ;
@@ -12,7 +12,7 @@ TACTIC EXTEND modal
   in	
   MPlugin.modal_tac_named modality c id
 ]
-| [ "modal_" constr(refl) constr(univ) constr(univ_to_univ) constr(forall) constr(unit) constr(c)] -> [
+| [ "modal_" reference(refl) reference(univ) reference(univ_to_univ) reference(forall) reference(unit) constr(c)] -> [
   let modality = {
       MTranslate.mod_O = refl;
       MTranslate.mod_univ = univ;

--- a/src/mTranslate.mli
+++ b/src/mTranslate.mli
@@ -1,11 +1,11 @@
 open Globnames
 
 type modality = {
-    mod_O : Constr.t;
-    mod_univ : Constr.t;
-    mod_univ_to_univ : Constr.t;
-    mod_forall : Constr.t;
-    mod_unit : Constr.t;
+    mod_O : global_reference;
+    mod_univ : global_reference;
+    mod_univ_to_univ : global_reference;
+    mod_forall : global_reference;
+    mod_unit : global_reference;
   }
 
 type translator = global_reference Refmap.t

--- a/test/Test.v
+++ b/test/Test.v
@@ -1,5 +1,3 @@
-(* -*- coq-prog-name: "/Users/kquiri13/Code/Coq/HoTT8.5/HoTT/hoqtop"; proof-prog-name-ask: nil -*- *)
-
 Require Import MTranslate.Modal.
 Require Import HoTT.
 
@@ -77,19 +75,19 @@ Module Test (Mod:Modalities) (Acc:Accessible_Modalities Mod).
       X.
 
       
-  Goal forall (O:Modality) (A:Type) (x:A), True.
-    intros O A x.       
-    _modal O Empty Oempty. cbn in *.
-    __modal O Unit. cbn in *.
-    __modal O nat. cbn in *.
-    __modal O Type.
-    __modal O (Type -> Type). cbn in *. 
-    __modal O (forall x:Type, x). cbn in *.
-    (* __modal O (forall x:Type, x -> x). *) 
-    (* __modal O ((fun x:Type => x) Type). *)
-    (* __modal O (forall x:Type, Type -> x). *)
-    (* __modal O ((fun x:Type => x) Type). *)
-  Abort.
+  (* Goal forall (O:Modality) (A:Type) (x:A), True. *)
+  (*   intros O A x.        *)
+  (*   _modal O Empty Oempty. cbn in *. *)
+  (*   __modal O Unit. cbn in *. *)
+  (*   __modal O nat. cbn in *. *)
+  (*   __modal O Type. *)
+  (*   __modal O (Type -> Type). cbn in *.  *)
+  (*   __modal O (forall x:Type, x). cbn in *. *)
+  (*   (* __modal O (forall x:Type, x -> x). *)  *)
+  (*   (* __modal O ((fun x:Type => x) Type). *) *)
+  (*   (* __modal O (forall x:Type, Type -> x). *) *)
+  (*   (* __modal O ((fun x:Type => x) Type). *) *)
+  (* Abort. *)
 
     Context {O:Modality}.
   Let Reflector  := fun X => (O_reflector O X; @O_inO O X).
@@ -101,11 +99,13 @@ Module Test (Mod:Modalities) (Acc:Accessible_Modalities Mod).
   Let OUnit  := ((Unit; inO_unit O) : Type_ O).
 
   
-
-  Modal Definition foo :Type using Reflector TypeO U2U Forall OUnit.
-  unfold TypeO, U2U, MType. cbn.
-  (* exact OUnit. *)
-  (*
+  (* Set Printing All. *)
+  (* Set Printing Universes. *)
+  Polymorphic Modal Definition foo :Type using Reflector TypeO U2U Forall OUnit.
+    unfold TypeO, U2U, MType. cbn.
+    apply OUnit.
+  Qed.
+Check foomodal.  (*
     Anomaly: File "pretyping/evd.ml", line 407, characters 15-21: Assertion failed.
     Please report.
    *)


### PR DESCRIPTION
Mon impression est que tu as besoin de différentes instances de U2U etc... au cours de la traduction, donc il vaut mieux prendre des réferences globales que l'ont peut rafraichir à l'envi (et éviter de générer des univers inutilisés si tu n'utilise pas toutes ces constantes). La définition de foo fonctionne ainsi. Pour adapter la tactique, je te suggère un type global_or_constr = Global of global_reference | Constr of Constr.t à utiliser dans modality dans les cas où tu sais que tu n'auras pas à rafraîchir. Mon analyse est correcte ?
